### PR TITLE
Tweaks to Singularity Recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ensemble-vep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # sherlock_vep
+
+## Instructions for building
+
+To build the container:
+
+```
+sudo singularity build ensembl-vep Singularity
+```
+
+And to run the software:
+
+```
+./ensembl-vep 
+#----------------------------------#
+# ENSEMBL VARIANT EFFECT PREDICTOR #
+#----------------------------------#
+
+Versions:
+  ensembl              : 91.18ee742
+  ensembl-funcgen      : 91.4681d69
+  ensembl-io           : 91.923d668
+  ensembl-variation    : 91.c78d8b4
+  ensembl-vep          : 91.3
+
+Help: dev@ensembl.org , helpdesk@ensembl.org
+Twitter: @ensembl , @EnsemblWill
+
+http://www.ensembl.org/info/docs/tools/vep/script/index.html
+
+Usage:
+./vep [--cache|--offline|--database] [arguments]
+
+Basic options
+=============
+
+--help                 Display this message and quit
+
+-i | --input_file      Input file
+-o | --output_file     Output file
+--force_overwrite      Force overwriting of output file
+--species [species]    Species to use [default: "human"]
+                       
+--everything           Shortcut switch to turn on commonly used options. See web
+                       documentation for details [default: off]                       
+--fork [num_forks]     Use forking to improve script runtime
+
+For full option documentation see:
+http://www.ensembl.org/info/docs/tools/vep/script/vep_options.html
+
+```
+
+If you have questions, please open an [issue](https://github.com/eilon-s/sherlock_vep/issues).

--- a/Singularity
+++ b/Singularity
@@ -1,21 +1,26 @@
 Bootstrap: docker
 From: willmclaren/ensembl-vep
 
+# sudo singularity build ensembl-vep Singularity
+
 %help
 This is a singularity file for VEP docker (v1)	
 
+%environment
+    LANGUAGE=en_US
+    LANG="en_US.UTF-8"
+    LC_ALL=C
+    export LANGUAGE LANG LC_ALL
+
 %post
-	mkdir -p ${SINGULARITY_ROOTFS}/.vep;
-	mkdir -p ${SINGULARITY_ROOTFS}/vep_genomes;
-	cd ${SINGULARITY_ROOTFS};
-	perl /home/vep/src/ensembl-vep/INSTALL.pl -a acf -s Saccharomyces_cerevisiae -y R64-1-1 -c ${SINGULARITY_ROOTFS}/.vep
-	perl /home/vep/src/ensembl-vep/INSTALL.pl -a acf -s homo_sapiens -y GRCh37 -c ${SINGULARITY_ROOTFS}/.vep
-	git clone https://github.com/Ensembl/VEP_plugins.git;
-	git clone https://github.com/griffithlab/pVAC-Seq.git;
-	cp ${SINGULARITY_ROOTFS}/pVAC-Seq/pvacseq/VEP_plugins/Wildtype.pm ${SINGULARITY_ROOTFS}/VEP_plugins;
-	rm -r ${SINGULARITY_ROOTFS}/pVAC-Seq;
-	
+    mkdir /.vep;
+    mkdir /vep_genomes;
+    perl /home/vep/src/ensembl-vep/INSTALL.pl -a acf -s Saccharomyces_cerevisiae -y R64-1-1 -c /.vep
+    perl /home/vep/src/ensembl-vep/INSTALL.pl -a acf -s homo_sapiens -y GRCh37 -c /.vep
+    git clone https://github.com/Ensembl/VEP_plugins.git;
+    git clone https://github.com/griffithlab/pVAC-Seq.git;
+    cp /pVAC-Seq/pvacseq/VEP_plugins/Wildtype.pm /VEP_plugins;
+    rm -r /pVAC-Seq;
 	
 %runscript
-	/home/vep/src/ensembl-vep/vep "$@"
-
+    exec /home/vep/src/ensembl-vep/vep "$@"


### PR DESCRIPTION
This PR will address the following:

 - removing the `SINGULARITY_ROOTFS` environment variable from `%post`. In this section we are working relative to the image, so the rootfs is represented at `/`. This variable is only needed in the `%setup` section if we need to move things from (our host) into the container.
 - adding a gitignore for the container that is built
 - adding environment variables for the locale so perl doesn't get angry with us :) These variables are set in the section called `%environment` that is sourced when the container is run, shelled, or exec'd to.

Likely if this takes too long it won't build on singularity hub, something that can be addressed with discussion and another PR.